### PR TITLE
Prompt Manager Advanced: Remove the category and name input sockets so they don't appear on the left side

### DIFF
--- a/js/prompt_manager_advanced.js
+++ b/js/prompt_manager_advanced.js
@@ -8073,6 +8073,13 @@ function createPromptSelectorWidget(node) {
     promptWidget.type = "converted-widget";
     promptWidget.computeSize = () => [0, -4];
 
+    for (let i = node.inputs.length - 1; i >= 0; i--) {
+        const inp = node.inputs[i];
+        if (inp.name === "category" || inp.name === "name") {
+            node.removeInput(i);
+        }
+    }
+
     // Create custom selector container
     const container = document.createElement("div");
     container.style.cssText = `


### PR DESCRIPTION
Remove the category and name input sockets so they don't appear on the left side
of the node and misalign with the BOOLEAN toggle sockets below them.
Iterate in reverse so removing by index doesn't shift remaining indices.