### PR TITLE
Fix/recursive model subfolder discovery

### DIFF
--- a/py/model_manager.py
+++ b/py/model_manager.py
@@ -238,7 +238,8 @@ def get_mmproj_path(model_name):
     """Get the path to the mmproj file for a model, if it exists.
 
     1. Check the explicit QWEN_MODELS mapping first.
-    2. Fall back to heuristic matching by model identity (strips quant parts).
+    2. If the model's own folder contains exactly one mmproj file, use it.
+    3. Fall back to heuristic matching by model identity (strips quant parts).
     """
     # --- 1. Explicit mapping ---
     mmproj_name = get_mmproj_for_model(model_name)
@@ -251,7 +252,19 @@ def get_mmproj_path(model_name):
         # Mapped but file not found on disk
         return None
 
-    # --- 2. Heuristic: keyword-based matching ---
+    # --- 2. Same-folder single-candidate fallback ---
+    # If the model lives in its own subfolder alongside exactly one mmproj
+    # file, assume that's the one to use — no naming convention required.
+    model_dir = os.path.dirname(get_model_path(model_name))
+    if os.path.isdir(model_dir):
+        sibling_mmprojs = [
+            f for f in os.listdir(model_dir)
+            if f.lower().endswith('.gguf') and 'mmproj' in f.lower()
+        ]
+        if len(sibling_mmprojs) == 1:
+            return os.path.join(model_dir, sibling_mmprojs[0])
+
+    # --- 3. Heuristic: keyword-based matching ---
     # Split the model name into normalised keywords (no quant tags, no 'mmproj')
     # and find the mmproj file that shares the most keywords (minimum 4).
     model_keywords = _get_model_keywords(model_name)
@@ -266,14 +279,15 @@ def get_mmproj_path(model_name):
     for models_dir in all_dirs:
         if not os.path.exists(models_dir):
             continue
-        for f in os.listdir(models_dir):
-            if 'mmproj' not in f.lower() or not f.endswith('.gguf'):
-                continue
-            mmproj_keywords = _get_model_keywords(f)
-            common = model_keywords & mmproj_keywords
-            if len(common) >= MIN_KEYWORD_MATCH and len(common) > best_match_count:
-                best_match = os.path.join(models_dir, f)
-                best_match_count = len(common)
+        for dirpath, _subdirs, filenames in os.walk(models_dir, followlinks=True):
+            for f in filenames:
+                if 'mmproj' not in f.lower() or not f.lower().endswith('.gguf'):
+                    continue
+                mmproj_keywords = _get_model_keywords(f)
+                common = model_keywords & mmproj_keywords
+                if len(common) >= MIN_KEYWORD_MATCH and len(common) > best_match_count:
+                    best_match = os.path.join(dirpath, f)
+                    best_match_count = len(common)
 
     return best_match
 

--- a/py/model_manager.py
+++ b/py/model_manager.py
@@ -2,7 +2,6 @@
 Utility functions for managing llama.cpp models
 """
 import os
-import glob
 import re
 import folder_paths
 import server
@@ -131,12 +130,13 @@ def get_local_models():
     all_models = set()  # Use set to avoid duplicates
     for models_dir in all_dirs:
         if os.path.exists(models_dir):
-            gguf_files = glob.glob(os.path.join(models_dir, "*.gguf"))
-            for f in gguf_files:
-                basename = os.path.basename(f)
-                # Filter out mmproj files
-                if 'mmproj' not in basename.lower():
-                    all_models.add(basename)
+            for dirpath, _subdirs, filenames in os.walk(models_dir, followlinks=True):
+                for filename in filenames:
+                    if not filename.lower().endswith(".gguf") or 'mmproj' in filename.lower():
+                        continue
+                    full_path = os.path.join(dirpath, filename)
+                    rel_path = os.path.relpath(full_path, models_dir)
+                    all_models.add(rel_path)
 
     # Return sorted list of unique filenames
     return sorted(list(all_models))


### PR DESCRIPTION
##  Description:

 Users who organize their models directory with per-model subfolders (e.g. ~/models/Gemma-4-31B-it/model.gguf, a common
 layout when downloading from HuggingFace) were missing those models entirely, and even when a model was found, its
 paired mmproj vision file often wasn't detected.

 ### Problem 1: Models in subfolders weren't listed

 get_local_models() used a non-recursive glob.glob(models_dir/*.gguf), so any .gguf file not directly inside the
 configured models directory was invisible to the plugin.

 Fix: Walk the directory tree with os.walk and return each match as a path relative to models_dir (e.g.
 Gemma-4-31B-it/model.gguf). This matches the relative-path convention ComfyUI's own folder_paths.recursive_search
 uses, so is_model_local() and get_model_path() — which already join models_dir with the returned name — work unchanged
 for subfolder entries.

 ## Problem 2: mmproj files weren't matched, even in the same folder as the model

 get_mmproj_path() had two separate issues:
 - It only scanned the top level of models_dir (os.listdir), so an mmproj file living in a model's own subfolder was
   never seen.
 - Its keyword-matching heuristic requires ≥4 shared non-quant keywords between model and mmproj filenames. Generic
   filenames like mmproj-BF16.gguf (common in many GGUF repos) carry no identifying keywords, so they could never match
   no matter where they lived.

 Fix: Added a same-folder fallback — if the model's own directory contains exactly one mmproj file, use it directly,
 with no naming convention required. If there are zero or multiple candidates in that folder, it's left to the existing
 keyword heuristic, which now also recurses into subfolders (for setups where the mmproj lives in a different folder
 than the model, e.g. a shared mmproj directory).

## Testing:

 Verified locally with a temporary models directory covering:
 - A model + single generically-named mmproj in the same subfolder → now correctly paired.
 - A model with two mmproj candidates in the same folder → correctly left unresolved (no bad guess).
 - Existing top-level keyword-matched model/mmproj pair → still works (no regression).
 - A model and mmproj in two different subfolders, matched only by filename keywords → still found via the
   now-recursive heuristic search.

 No changes to public function signatures — is_model_local, get_model_path, get_mmproj_path, and has_vision_support all
 keep their existing contracts.